### PR TITLE
Specify bucket name and allow other partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ module "cloudtrail-bucket" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allowed\_account\_ids | Optional list of AWS Account IDs that are permitted to write to the bucket | list(string) | `[]` | no |
+| bucket\_name | Optional name for cloudtrail bucket | string | `{account_id}-{region}-cloudtrail` | no |
 | logging\_bucket | S3 bucket with suitable access for logging requests to the cloudtrail bucket | string | n/a | yes |
 | region | Region to create KMS key in | string | n/a | yes |
 | tags | Mapping of any extra tags you want added to resources | map(string) | `{}` | no |

--- a/kms.tf
+++ b/kms.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "key" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+      identifiers = ["arn:${local.partition}:iam::${local.account_id}:root"]
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,19 @@
 data "aws_caller_identity" "current" {
 }
 
+data "aws_partition" "current" {
+}
+
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
 
   # Account IDs that will have access to stream CloudTrail logs
   account_ids = concat([local.account_id], var.allowed_account_ids)
 
   # Format account IDs into necessary resource lists.
   bucket_policy_put_resources = formatlist("${aws_s3_bucket.this.arn}/AWSLogs/%s/*", local.account_ids)
-  kms_key_encrypt_resources   = formatlist("arn:aws:cloudtrail:*:%s:trail/*", local.account_ids)
+  kms_key_encrypt_resources   = formatlist("arn:${local.partition}:cloudtrail:*:%s:trail/*", local.account_ids)
 }
 
 resource "aws_s3_bucket" "this" {

--- a/main.tf
+++ b/main.tf
@@ -5,10 +5,9 @@ data "aws_partition" "current" {
 }
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
-  partition  = data.aws_partition.current.partition
-
-  bucket_name = var.bucket_name == "" ? "${local.account_id}-${var.region}-cloudtrail" : var.bucket_name
+  account_id  = data.aws_caller_identity.current.account_id
+  bucket_name = var.bucket_name == null ? "${local.account_id}-${var.region}-cloudtrail" : var.bucket_name
+  partition   = data.aws_partition.current.partition
 
   # Account IDs that will have access to stream CloudTrail logs
   account_ids = concat([local.account_id], var.allowed_account_ids)

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,8 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
 
+  bucket_name = var.bucket_name == "" ? "${local.account_id}-${var.region}-cloudtrail" : var.bucket_name
+
   # Account IDs that will have access to stream CloudTrail logs
   account_ids = concat([local.account_id], var.allowed_account_ids)
 
@@ -17,7 +19,7 @@ locals {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket = "${local.account_id}-${var.region}-cloudtrail"
+  bucket = local.bucket_name
   acl    = "private"
   tags   = var.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "allowed_account_ids" {
 }
 
 variable "bucket_name" {
-  default     = "" # can't dynamically build the bucket name here
+  default     = null # can't dynamically build the bucket name here
   description = "Name of the S3 bucket to create. Defaults to {account_id}-{region}-cloudtrail."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "allowed_account_ids" {
   type        = list(string)
 }
 
+variable "bucket_name" {
+  default     = "" # can't dynamically build the bucket name here
+  description = "Name of the S3 bucket to create. Defaults to {account_id}-{region}-cloudtrail."
+  type        = string
+}
+
 variable "logging_bucket" {
   description = "S3 bucket with suitable access for logging requests to the cloudtrail bucket"
   type        = string


### PR DESCRIPTION
Thanks for the modules.

I made two minor improvements:
* ARNs are now built with the current partition, which allows this to work in GovCloud, and likely China, too.
* You can now specify the bucket name. The default name (`{account_id}-{region}-cloudtrail`) was both predictable and didn't make a lot of sense for me with cross-account logging.

Neither change breaks backward compatibility.
