### PR TITLE
Allowing roles to use KMS:decrypt to allow reading logs from s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ module "cloudtrail-bucket" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-| Name                         | Description                                                                               |     Type     | Default | Required |
-|------------------------------|-------------------------------------------------------------------------------------------|:------------:|:-------:|:--------:|
-| allowed\_account\_ids        | Optional list of AWS Account IDs that are permitted to write to the bucket                | list(string) |  `[]`   |    no    |
+| Name                         | Description                                                                              |     Type     | Default | Required |
+|------------------------------|------------------------------------------------------------------------------------------|:------------:|:-------:|:--------:|
+| allowed\_account\_ids        | Optional list of AWS Account IDs that are permitted to write to the bucket               | list(string) |  `[]`   |    no    |
 | roles\_allowed\_kms\_decrypt | Optional list of roles that have access to KMS decrypt and are permitted to decrypt logs | list(string) |  `[]`   |    no    |
-| logging\_bucket              | S3 bucket with suitable access for logging requests to the cloudtrail bucket              |    string    |   n/a   |   yes    |
-| region                       | Region to create KMS key in                                                               |    string    |   n/a   |   yes    |
-| tags                         | Mapping of any extra tags you want added to resources                                     | map(string)  |  `{}`   |    no    |
+| logging\_bucket              | S3 bucket with suitable access for logging requests to the cloudtrail bucket             |    string    |   n/a   |   yes    |
+| region                       | Region to create KMS key in                                                              |    string    |   n/a   |   yes    |
+| tags                         | Mapping of any extra tags you want added to resources                                    | map(string)  |  `{}`   |    no    |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ module "cloudtrail-bucket" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| allowed\_account\_ids | Optional list of AWS Account IDs that are permitted to write to the bucket | list(string) | `[]` | no |
-| logging\_bucket | S3 bucket with suitable access for logging requests to the cloudtrail bucket | string | n/a | yes |
-| region | Region to create KMS key in | string | n/a | yes |
-| tags | Mapping of any extra tags you want added to resources | map(string) | `{}` | no |
+| Name                         | Description                                                                               |     Type     | Default | Required |
+|------------------------------|-------------------------------------------------------------------------------------------|:------------:|:-------:|:--------:|
+| allowed\_account\_ids        | Optional list of AWS Account IDs that are permitted to write to the bucket                | list(string) |  `[]`   |    no    |
+| roles\_allowed\_kms\_decrypt | Optional list of roles that have access to KMS decrypt and are permitted to decrypt logs | list(string) |  `[]`   |    no    |
+| logging\_bucket              | S3 bucket with suitable access for logging requests to the cloudtrail bucket              |    string    |   n/a   |   yes    |
+| region                       | Region to create KMS key in                                                               |    string    |   n/a   |   yes    |
+| tags                         | Mapping of any extra tags you want added to resources                                     | map(string)  |  `{}`   |    no    |
 
 ## Outputs
 

--- a/kms.tf
+++ b/kms.tf
@@ -54,6 +54,17 @@ data "aws_iam_policy_document" "key" {
       identifiers = ["cloudtrail.amazonaws.com"]
     }
   }
+
+  statement {
+    actions   = ["kms:Decrypt"]
+    effect    = "Allow"
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = local.allow_kms_decrypt
+    }
+  }
 }
 
 resource "aws_kms_key" "this" {

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,9 @@ locals {
   # Format account IDs into necessary resource lists.
   bucket_policy_put_resources = formatlist("${aws_s3_bucket.this.arn}/AWSLogs/%s/*", local.account_ids)
   kms_key_encrypt_resources   = formatlist("arn:aws:cloudtrail:*:%s:trail/*", local.account_ids)
+
+  # Roles that will have access to KMS decrypt, can be used to grant read access to logs in S3
+  allow_kms_decrypt = formatlist("arn:aws:iam::${local.account_id}:role/%s", var.roles_allowed_kms_decrypt)
 }
 
 resource "aws_s3_bucket" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "allowed_account_ids" {
   type        = list(string)
 }
 
+variable "roles_allowed_kms_decrypt" {
+  default     = []
+  description = "Optional list of roles that have access to KMS decrypt and are permitted to decrypt logs"
+  type        = list(string)
+}
+
 variable "logging_bucket" {
   description = "S3 bucket with suitable access for logging requests to the cloudtrail bucket"
   type        = string


### PR DESCRIPTION
Currently there is no way to allow roles to read logs in S3.

This PR grants KMS:decrypt permission that will allow assumed roles to read S3 stored Cloudtrail logs.